### PR TITLE
Changed checks for disabled disks

### DIFF
--- a/CIS_benchmarks_ubuntu_16_04_LTS.sh
+++ b/CIS_benchmarks_ubuntu_16_04_LTS.sh
@@ -2,7 +2,7 @@
 
 disable_cramfs () {
 	echo -e "\e[92m== 1.1.1.1 Ensure mounting of cramfs filesystems is disabled ==\e\n"
-	if [[ "$(modprobe -n -v cramfs 2>/dev/null)" = *install* ]]
+        if [[ "$(grep cramfs /etc/modprobe.d/CIS.conf 2>/dev/null)" = *install* ]]
 		then echo "Passed!"
 	else
 		echo -e "\e[31mFailed!\e[0m : \nVerify output of 'modprobe -n -v cramfs' command.  Should show this output: \n
@@ -112,7 +112,7 @@ disable_hfsplus () {
 
 disable_squashfs () {
         echo -e "\e[92m== 1.1.1.6 Ensure mounting of squashfs filesystems is disabled ==\e\n"
-        if [[ "$(modprobe -n -v squashfs 2>/dev/null)" = *install* ]]
+        if [[ "$(grep squashfs /etc/modprobe.d/CIS.conf 2>/dev/null)" = *install* ]]
                 then echo "Passed!"
         else
                 echo -e "\e[31mFailed!\e[0m : \nVerify output of 'modprobe -n -v squashfs' command.  Should show this output: \n
@@ -156,7 +156,7 @@ disable_udf () {
 
 disable_fat () {
         echo -e "\e[92m== 1.1.1.8 Ensure mounting of fat filesystems is disabled ==\e\n"
-        if [[ "$(modprobe -n -v vfat 2>/dev/null)" = *install* ]]
+        if [[ "$(grep vfat /etc/modprobe.d/CIS.conf 2>/dev/null)" = *install* ]]
                 then echo "Passed!"
         else
                 echo -e "\e[31mFailed!\e[0m : \nVerify output of 'modprobe -n -v vfat' command.  Should show this output: \n

--- a/CIS_benchmarks_ubuntu_16_04_LTS.sh
+++ b/CIS_benchmarks_ubuntu_16_04_LTS.sh
@@ -2,7 +2,7 @@
 
 disable_cramfs () {
 	echo -e "\e[92m== 1.1.1.1 Ensure mounting of cramfs filesystems is disabled ==\e\n"
-        if [[ "$(grep cramfs /etc/modprobe.d/CIS.conf 2>/dev/null)" = *install* ]]
+	if [[ "$(modprobe -n -v cramfs 2>/dev/null)" = *install* ]]
 		then echo "Passed!"
 	else
 		echo -e "\e[31mFailed!\e[0m : \nVerify output of 'modprobe -n -v cramfs' command.  Should show this output: \n


### PR DESCRIPTION
Some filesystem types are built into ubuntu now, so the changes they give don't really apply anymore.  Now, it just checks in the CIS.conf file to make sure it's shown as disabled there for cramfs, squashfs and vfat